### PR TITLE
Remove NA index rows from HD extract script + add attendance_6to17yo column

### DIFF
--- a/human_development/global_data_lab_hid_transform_load_dlt.py
+++ b/human_development/global_data_lab_hid_transform_load_dlt.py
@@ -70,7 +70,7 @@ def global_data_lab_hd_index():
             ).otherwise(
                 F.col("Region")
             ))
-        .withColumn("attendance_6to17yo", col('attendance')/100)
+        .withColumn("attendance_6to17yo", F.col('attendance')/100)
         .select(
             'country_name',
             'adm1_name',

--- a/human_development/global_data_lab_hid_transform_load_dlt.py
+++ b/human_development/global_data_lab_hid_transform_load_dlt.py
@@ -70,6 +70,7 @@ def global_data_lab_hd_index():
             ).otherwise(
                 F.col("Region")
             ))
+        .withColumn("attendance_6to17yo", col('attendance')/100)
         .select(
             'country_name',
             'adm1_name',
@@ -78,5 +79,6 @@ def global_data_lab_hd_index():
             F.col('healthindex').alias('health_index'),
             F.col('incindex').alias('income_index'),
             'attendance',
+            'attendance_6to17yo',
         )
     )


### PR DESCRIPTION
HD extract was failing due to duplicate Palestine rows with NA values. This fixes it by dropping all the rows with index=NA.
- Also add attendance_6to17yo which uses the same scale as the rest of the HD indexes to be consistent.
- attendance to be deprecated once PowerBI is phased out