### PR TITLE
updating the energy api url to reflect ember-energy

### DIFF
--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -7,17 +7,22 @@ import requests
 
 # Load dataset from the API
 my_api_key = dbutils.secrets.get(scope="DIMEBOOSTKEYVAULT", key="ember_energy_key")
-base_url = "https://api.ember-climate.org"
+base_url = "https://api.ember-energy.org"
 query_url = (
     f"{base_url}/v1/electricity-generation/yearly"
-    + f"?is_aggregate_series=false&api_key={my_api_key}"
+    + "?"
+    + f"is_aggregate_series=false"
+    + f"&api_key={temp}"
 )
 
-response = requests.get(query_url)
+response = requests.get(query_url, timeout=10)
 
 if response.status_code == 200:
     data = response.json()
-raw_df = pd.DataFrame(data["data"])
+    raw_df = pd.DataFrame(data["data"]) 
+else:
+    print(response)
+
 
 # COMMAND ----------
 

--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -16,14 +16,8 @@ query_url = (
 )
 
 response = requests.get(query_url)
-# codes in the 200 range are considered 'successes'
-WHITELIST_STATUS_CODES = list(range(200,300))
+response.raise_for_status()
 
-# Check if the response status code is in the whitelist
-if response.status_code not in WHITELIST_STATUS_CODES:
-    raise ValueError(f"Unexpected status code {response.status_code}. Expected one of {WHITELIST_STATUS_CODES}.")
-    
-# If status code is in whitelist, continue on to process the data
 data = response.json()
 raw_df = pd.DataFrame(data["data"])
 

--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -12,7 +12,7 @@ query_url = (
     f"{base_url}/v1/electricity-generation/yearly"
     + "?"
     + f"is_aggregate_series=false"
-    + f"&api_key={temp}"
+    + f"&api_key={my_api_key}"
 )
 
 response = requests.get(query_url, timeout=10)

--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -15,14 +15,17 @@ query_url = (
     + f"&api_key={my_api_key}"
 )
 
-response = requests.get(query_url, timeout=10)
+response = requests.get(query_url)
+# codes in the 200 range are considered 'successes'
+WHITELIST_STATUS_CODES = list(range(200,300))
 
-if response.status_code == 200:
-    data = response.json()
-    raw_df = pd.DataFrame(data["data"]) 
-else:
-    print(response)
-
+# Check if the response status code is in the whitelist
+if response.status_code not in WHITELIST_STATUS_CODES:
+    raise ValueError(f"Unexpected status code {response.status_code}. Expected one of {WHITELIST_STATUS_CODES}.")
+    
+# If status code is in whitelist, continue on to process the data
+data = response.json()
+raw_df = pd.DataFrame(data["data"])
 
 # COMMAND ----------
 


### PR DESCRIPTION
other changes for readability and better error reporting

## What?
energy api url to reflect ember-energy
## Why?
API url updated
## How?
- replaced `ember-climate` with `ember-energy`
- updated status code whitelist to only receive 200 range codes
## Testing?
tested on local device and again on the server
## Screenshots (optional)
## Anything Else?