### PR TITLE
GDL API error fix

### DIFF
--- a/human_development/global_data_lab_hdi_extract.r
+++ b/human_development/global_data_lab_hdi_extract.r
@@ -26,6 +26,19 @@ END_YEAR <- as.integer(format(Sys.Date(), "%Y"))
 
 # COMMAND ----------
 
+# TODO: Remove this as the issue https://github.com/GlobalDataLab/R-data-api/issues/5 is resolved.
+# This line here is overwriting gdl data API function
+set_countries_all <- function(sess) {
+  if (!is(sess, GDLSession)) {
+    stop("Primary argument must be a GDL Session Object")
+  }
+
+  sess@countries <- character(0)
+  return(sess)
+}
+
+# COMMAND ----------
+
 sess <- sess %>%
     set_dataset(DATASET) %>%
     set_countries_all() %>%

--- a/human_development/global_data_lab_hdi_extract.r
+++ b/human_development/global_data_lab_hdi_extract.r
@@ -6,7 +6,6 @@ install.packages("gdldata")
 library(gdldata)
 library(magrittr)
 library(SparkR)
-sparkR.session(appName = "global_data_lab")
 
 
 # COMMAND ----------
@@ -29,22 +28,9 @@ END_YEAR <- as.integer(format(Sys.Date(), "%Y"))
 
 # COMMAND ----------
 
-# TODO: Remove this as the issue https://github.com/GlobalDataLab/R-data-api/issues/5 is resolved.
-# This line here is overwriting gdl data API function
-set_countries_all <- function(sess) {
-  if (!is(sess, GDLSession)) {
-    stop("Primary argument must be a GDL Session Object")
-  }
-
-  sess@countries <- character(0)
-  return(sess)
-}
-
-# COMMAND ----------
-
 sess <- sess %>%
     set_dataset(DATASET) %>%
-    set_countries_all() %>%
+    set_countries(character(0)) %>% # Workaround for https://github.com/GlobalDataLab/R-data-api/issues/5. Replace this line with set_countries_all when the issue is resolved
     set_year(START_YEAR) %>%
     set_indicators(INDICATORS)
 indicator_merged <- gdl_request(sess)
@@ -55,7 +41,7 @@ print(paste(START_YEAR, 'nrow:', nrow(indicator_merged)))
 for (year in (START_YEAR+1):END_YEAR) {
   sess <- sess %>%
     set_dataset(DATASET) %>%
-    set_countries_all() %>%
+    set_countries(character(0)) %>% # Workaround for https://github.com/GlobalDataLab/R-data-api/issues/5. Replace this line with set_countries_all when the issue is resolved
     set_year(year) %>%
     set_indicators(INDICATORS)
   shdi <- gdl_request(sess)
@@ -76,7 +62,7 @@ END_YEAR <- as.integer(format(Sys.Date(), "%Y"))
 for (year in START_YEAR:END_YEAR) {
   sess <- sess %>%
       set_dataset(DATASET) %>%
-      set_countries_all() %>%
+      set_countries(character(0)) %>% # Workaround for https://github.com/GlobalDataLab/R-data-api/issues/5. Replace this line with set_countries_all when the issue is resolved
       set_year(year) %>%
       set_indicators(INDICATORS)
 

--- a/human_development/global_data_lab_hdi_extract.r
+++ b/human_development/global_data_lab_hdi_extract.r
@@ -182,7 +182,7 @@ if (!all(grouped_counts$obs_count == 1)) {
 
 
 sdf <- createDataFrame(collapsed_df)
-table_name <- paste0("prd_mega.indicator_intermediate.global_data_lab_hd_index_test")
+table_name <- paste0("prd_mega.indicator_intermediate.global_data_lab_hd_index")
 saveAsTable(sdf, tableName = table_name, mode = "overwrite",  overwriteSchema = "true")
 
 print(paste(table_name, 'nrow:', nrow(collapsed_df)))

--- a/population/global_data_lab_subnational_population.r
+++ b/population/global_data_lab_subnational_population.r
@@ -25,11 +25,10 @@ library(SparkR)
 sess <- sess %>%
     set_dataset('demographics') %>%
     set_countries(character(0)) %>% #Workaround for  https://github.com/GlobalDataLab/R-data-api/issues/5. Replace this line with set_countries_all when the issue is resolved
-    set_indicators(c('regpopm')) %>%
+    set_indicators(c('regpopm'))
     # by default linear extrapolation for 3 years
     # disabling extrapolation doesn't seem to work
     # set_extrapolation_years_linear(0) %>%
-    set_interpolation(TRUE)
 spop_merged <- gdl_request(sess)
 sdf <- createDataFrame(spop_merged)
 table_name <- paste0("prd_mega.indicator_intermediate.global_data_lab_subnational_population_bronze")

--- a/population/global_data_lab_subnational_population.r
+++ b/population/global_data_lab_subnational_population.r
@@ -89,7 +89,7 @@ df_no_extrapolation <- df_population_bronze %>%
 
 library(dplyr)
 sdf <- createDataFrame(df_no_extrapolation)
-table_name <- paste0("prd_mega.indicator.global_data_lab_subnational_population_test")
+table_name <- paste0("prd_mega.indicator.global_data_lab_subnational_population")
 saveAsTable(sdf, tableName = table_name, mode = "overwrite")
 
 print(paste(table_name, 'nrow:', nrow(df_no_extrapolation)))

--- a/population/global_data_lab_subnational_population.r
+++ b/population/global_data_lab_subnational_population.r
@@ -29,46 +29,67 @@ set_countries_all <- function(sess) {
 
 # COMMAND ----------
 
+library(tidyr)
+library(readr)
+library(SparkR)
+sparkR.session(appName = "global_data_lab")
+
+# COMMAND ----------
+
 sess <- sess %>%
     set_dataset('demographics') %>%
     set_countries_all() %>%
-    set_indicators(c('regpopm'))
+    set_indicators(c('regpopm')) %>%
     # by default linear extrapolation for 3 years
     # disabling extrapolation doesn't seem to work
     # set_extrapolation_years_linear(0) %>%
-    # set_extrapolation_years_nearest(0) %>%
-    # set_interpolation(TRUE)
+    set_interpolation(TRUE)
 spop_merged <- gdl_request(sess)
+sdf <- createDataFrame(spop_merged)
+table_name <- paste0("prd_mega.indicator_intermediate.global_data_lab_subnational_population_bronze")
+saveAsTable(sdf, tableName = table_name, mode = "overwrite")
+
 print(colnames(spop_merged))
 print(paste('nrow:', nrow(spop_merged)))
 
 # COMMAND ----------
 
-library(tidyr)
-library(readr)
-library(SparkR)
-hive_config <- list("spark.sql.catalogImplementation" = "hive")
-sparkR.session(appName = "global_data_lab", config = hive_config)
+sdf <- SparkR::sql("SELECT * FROM prd_mega.indicator_intermediate.global_data_lab_subnational_population_bronze")
+df_population_bronze <-SparkR:: collect(sdf)
+
+# Rename columns in the R data.frame
+df_population_bronze <- df_population_bronze %>%
+  dplyr::rename(
+    year = Year,
+    population_millions = regpopm
+  )
+
+# Define the mapping vector for country name 
+renames <- c(
+  "Congo Democratic Republic" = "Congo, Dem. Rep.",
+  "Chili"                     = "Chile"
+)
+
+# Apply the replacements to the Country column
+df_population_bronze <- df_population_bronze %>%
+  dplyr::mutate(Country = dplyr::recode(Country, !!!renames))
 
 # COMMAND ----------
 
 library(dplyr)
 
-key <- 'X'
-
-df <- gather(spop_merged, key = key, value = 'population_millions', -Country, -Continent, -ISO_Code, -Level, -GDLCODE, -Region) %>%
-  mutate(year = as.integer(parse_number(key))) %>%
-  select(-key)
-
-df_no_extrapolation <- df %>%
+df_no_extrapolation <- df_population_bronze %>%
   filter(!is.na(population_millions)) %>%  # Drop rows where population_millions is null
   group_by(Country, Region) %>%
   arrange(Country, Region, desc(year)) %>%  
   filter(row_number() > 3, row_number() <= n() - 3) %>%  # Drop extrapolated years (first & last 3 years given Country, Region)
   ungroup()
 
+# COMMAND ----------
+
+library(dplyr)
 sdf <- createDataFrame(df_no_extrapolation)
-table_name <- paste0("prd_mega.indicator.global_data_lab_subnational_population")
+table_name <- paste0("prd_mega.indicator.global_data_lab_subnational_population_test")
 saveAsTable(sdf, tableName = table_name, mode = "overwrite")
 
 print(paste(table_name, 'nrow:', nrow(df_no_extrapolation)))

--- a/population/global_data_lab_subnational_population.r
+++ b/population/global_data_lab_subnational_population.r
@@ -16,6 +16,19 @@ sess <- gdl_session(api_token)
 
 # COMMAND ----------
 
+# TODO: Remove this as the issue https://github.com/GlobalDataLab/R-data-api/issues/5 is resolved.
+# This line here is overwriting gdl data API function
+set_countries_all <- function(sess) {
+  if (!is(sess, GDLSession)) {
+    stop("Primary argument must be a GDL Session Object")
+  }
+
+  sess@countries <- character(0)
+  return(sess)
+}
+
+# COMMAND ----------
+
 sess <- sess %>%
     set_dataset('demographics') %>%
     set_countries_all() %>%

--- a/population/global_data_lab_subnational_population.r
+++ b/population/global_data_lab_subnational_population.r
@@ -16,29 +16,15 @@ sess <- gdl_session(api_token)
 
 # COMMAND ----------
 
-# TODO: Remove this as the issue https://github.com/GlobalDataLab/R-data-api/issues/5 is resolved.
-# This line here is overwriting gdl data API function
-set_countries_all <- function(sess) {
-  if (!is(sess, GDLSession)) {
-    stop("Primary argument must be a GDL Session Object")
-  }
-
-  sess@countries <- character(0)
-  return(sess)
-}
-
-# COMMAND ----------
-
 library(tidyr)
 library(readr)
 library(SparkR)
-sparkR.session(appName = "global_data_lab")
 
 # COMMAND ----------
 
 sess <- sess %>%
     set_dataset('demographics') %>%
-    set_countries_all() %>%
+    set_countries(character(0)) %>% #Workaround for  https://github.com/GlobalDataLab/R-data-api/issues/5. Replace this line with set_countries_all when the issue is resolved
     set_indicators(c('regpopm')) %>%
     # by default linear extrapolation for 3 years
     # disabling extrapolation doesn't seem to work

--- a/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
+++ b/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
@@ -11,7 +11,8 @@ import re
 
 # COMMAND ----------
 
-spid_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0064796/DR0092191/subnational-poverty-inequality-spid-poverty.xlsx?versionId=2023-09-11T14:24:15.5456758Z'
+spid_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0064796/2/DR0092191/subnational-poverty-inequality-spid-poverty.xlsx'
+
 response = requests.get(spid_url)
 if response.status_code == 200:
     df_SPID = pd.read_excel(BytesIO(response.content))
@@ -28,7 +29,7 @@ df_SPID.admlevel.unique()
 
 # COMMAND ----------
 
-gsap_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0042041/DR0052555/global-subnational-poverty-gsap-2019-data.xlsx?versionId=2023-09-11T14:26:49.3938437Z'
+gsap_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0042041/4/DR0052555/global-subnational-poverty-gsap-2019-data.xlsx'
 response = requests.get(gsap_url)
 if response.status_code == 200:
     df_GSAP = pd.read_excel(BytesIO(response.content))

--- a/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
+++ b/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
@@ -11,8 +11,7 @@ import re
 
 # COMMAND ----------
 
-spid_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0064796/2/DR0092191/subnational-poverty-inequality-spid-poverty.xlsx'
-
+spid_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0064796/DR0092191/subnational-poverty-inequality-spid-poverty.xlsx?versionId=2023-09-11T14:24:15.5456758Z'
 response = requests.get(spid_url)
 if response.status_code == 200:
     df_SPID = pd.read_excel(BytesIO(response.content))
@@ -29,7 +28,7 @@ df_SPID.admlevel.unique()
 
 # COMMAND ----------
 
-gsap_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0042041/4/DR0052555/global-subnational-poverty-gsap-2019-data.xlsx'
+gsap_url = 'https://datacatalogfiles.worldbank.org/ddh-published/0042041/DR0052555/global-subnational-poverty-gsap-2019-data.xlsx?versionId=2023-09-11T14:26:49.3938437Z'
 response = requests.get(gsap_url)
 if response.status_code == 200:
     df_GSAP = pd.read_excel(BytesIO(response.content))


### PR DESCRIPTION
This PR fixes the monthly indicator pipeline through the following changes:

1. Implements a workaround for a GDL API bug: Addressed the issue where set_countries_all is non-functional ([Issue #5](https://github.com/GlobalDataLab/R-data-api/issues/5)).

2. Adjusts for API schema changes: The API now returns data in long format rather than the previous wide format. I updated the data processing logic to accommodate this change in the return structure. (HD data)

3. Introduces raw data persistence: The raw API response is now saved to the indicator_intermediate schema. This provides a snapshot of the source data to simplify debugging if the API format changes again in the future.