### PR TITLE
Add request timeouts to prevent hung tasks; remove unused imports

### DIFF
--- a/consumer_price_index.py
+++ b/consumer_price_index.py
@@ -6,9 +6,7 @@
 import requests
 import zipfile
 import io
-import os
 import pandas as pd
-from tempfile import gettempdir
 
 INDICATOR = 'FP.CPI.TOTL'
 URL = 'https://api.worldbank.org/v2/en/indicator/FP.CPI.TOTL?downloadformat=csv'

--- a/consumer_price_index.py
+++ b/consumer_price_index.py
@@ -13,7 +13,7 @@ from tempfile import gettempdir
 INDICATOR = 'FP.CPI.TOTL'
 URL = 'https://api.worldbank.org/v2/en/indicator/FP.CPI.TOTL?downloadformat=csv'
 
-response = requests.get(URL)
+response = requests.get(URL, timeout=60)
 
 if response.status_code != 200:
     print('Request returned non-200', response.status_code)

--- a/country.py
+++ b/country.py
@@ -10,7 +10,7 @@
 
 import wbgapi as wb
 import pyspark.sql.functions as F
-from pyspark.sql.types import StructType, StructField, DoubleType, StringType
+from pyspark.sql.types import StructType, StructField, DoubleType
 from pyspark.sql import Window
 from shapely.geometry import shape, MultiPolygon, Polygon
 import json

--- a/education/education_private_spending.py
+++ b/education/education_private_spending.py
@@ -13,7 +13,7 @@ HEADERS = {
 }
 
 # OECD API returns 403: Forbidden if no headers
-response = requests.get(URL, headers=HEADERS)
+response = requests.get(URL, headers=HEADERS, timeout=60)
 response.raise_for_status()
 
 # COMMAND ----------

--- a/education/education_public_spending.py
+++ b/education/education_public_spending.py
@@ -14,7 +14,7 @@ from tempfile import gettempdir
 INDICATOR = 'SE.XPD.TOTL.GD.ZS'
 URL = f'https://api.worldbank.org/v2/en/indicator/{INDICATOR}?downloadformat=csv'
 
-response = requests.get(URL)
+response = requests.get(URL, timeout=60)
 
 if response.status_code != 200:
     print('Request returned non-200', response.status_code)

--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -19,7 +19,7 @@ query_url = (
     + f"&api_key={my_api_key}"
 )
 
-response = requests.get(query_url)
+response = requests.get(query_url, timeout=60)
 response.raise_for_status()
 
 data = response.json()

--- a/energy/energy_generation_consumption.py
+++ b/energy/energy_generation_consumption.py
@@ -4,7 +4,6 @@
 # COMMAND ----------
 
 import pandas as pd
-from pathlib import Path
 import requests
 
 # COMMAND ----------

--- a/geo/admin_boundaries_dlt.py
+++ b/geo/admin_boundaries_dlt.py
@@ -4,16 +4,14 @@ dbutils.library.restartPython()
 
 # COMMAND ----------
 
-import requests
-import os
 import dlt
 import pandas as pd
 import json
 from itertools import chain
-from shapely.geometry import Polygon, shape, MultiPolygon
-from pyspark.sql.functions import col, first, collect_list, StringType, udf, when, lit, create_map, coalesce
+from shapely.geometry import shape
+from pyspark.sql.functions import col, first, collect_list, StringType, udf, lit, create_map, coalesce
 from functools import reduce
-from pyspark.sql.types import StructType, StructField, DoubleType, StringType
+from pyspark.sql.types import StringType
 from shapely.ops import unary_union
 
 # Same suffix scheme as config.py (vboost4_staging mirrors vboost4); DLT can't %run
@@ -242,10 +240,6 @@ def admin1_boundaries_gold():
     )
 
 # COMMAND ----------
-
-import json
-import pandas as pd
-import dlt
 
 ADMIN0_DATA_DIR = f'{VOLUME_ROOT_PATH}/auxiliary_data/admin0geoboundaries'
 disputed_area_country_map = {

--- a/geo/admin_boundaries_dlt.py
+++ b/geo/admin_boundaries_dlt.py
@@ -9,7 +9,7 @@ import pandas as pd
 import json
 from itertools import chain
 from shapely.geometry import shape
-from pyspark.sql.functions import col, first, collect_list, StringType, udf, lit, create_map, coalesce
+from pyspark.sql.functions import col, first, collect_list, udf, lit, create_map, coalesce
 from functools import reduce
 from pyspark.sql.types import StringType
 from shapely.ops import unary_union

--- a/health/health_expenditure.py
+++ b/health/health_expenditure.py
@@ -34,7 +34,7 @@ indicators = {
 df = pd.DataFrame()
 for indicator, value in indicators.items():
     url = f"https://ghoapi.azureedge.net/api/{indicator}"
-    resp = requests.get(url)
+    resp = requests.get(url, timeout=60)
     ddf = pd.DataFrame(resp.json()['value'])
     ddf = ddf[ddf.SpatialDimType=='COUNTRY'][['SpatialDim', 'ParentLocationCode', 'TimeDim', 'NumericValue']]
     ddf.rename(columns={'NumericValue': value}, inplace=True)

--- a/health/health_expenditure.py
+++ b/health/health_expenditure.py
@@ -35,6 +35,7 @@ df = pd.DataFrame()
 for indicator, value in indicators.items():
     url = f"https://ghoapi.azureedge.net/api/{indicator}"
     resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
     ddf = pd.DataFrame(resp.json()['value'])
     ddf = ddf[ddf.SpatialDimType=='COUNTRY'][['SpatialDim', 'ParentLocationCode', 'TimeDim', 'NumericValue']]
     ddf.rename(columns={'NumericValue': value}, inplace=True)

--- a/pefa/pefa_transform_load.py
+++ b/pefa/pefa_transform_load.py
@@ -9,7 +9,6 @@
 #      and once for 2011 framework then uploaded to {INDICATOR_SCHEMA}.pefa_2011_bronze
 
 import pandas as pd
-from sklearn.preprocessing import StandardScaler
 import re
 
 SCORE_MAPPING = {

--- a/population/BTN/btn_subnational_population.py
+++ b/population/BTN/btn_subnational_population.py
@@ -3,8 +3,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
 # Shared download+parse across countries (wb_subnational_population_extract.py).
 ddf_pop = (
     spark.table(f'{INDICATOR_SCHEMA}.wb_subnational_population_silver')

--- a/population/CHL/chl_subnational_population.py
+++ b/population/CHL/chl_subnational_population.py
@@ -3,8 +3,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
 # Shared download+parse across countries (wb_subnational_population_extract.py).
 ddf_pop = (
     spark.table(f'{INDICATOR_SCHEMA}.wb_subnational_population_silver')

--- a/population/COD/cod_subnational_population.py
+++ b/population/COD/cod_subnational_population.py
@@ -3,10 +3,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
-# COMMAND ----------
-
 # helper name correction map
 adm1_name_map = {
     'kasai oriental':'kasai-oriental',

--- a/population/MOZ/moz_subnational_population.py
+++ b/population/MOZ/moz_subnational_population.py
@@ -4,19 +4,27 @@
 # COMMAND ----------
 
 import unicodedata
+from io import BytesIO
+import requests
 import pandas as pd
 
 # COMMAND ----------
 
+def _fetch_csv(url, **kwargs):
+    """pd.read_csv(url) has no way to pass a timeout — fetch explicitly instead."""
+    resp = requests.get(url, timeout=60)
+    resp.raise_for_status()
+    return pd.read_csv(BytesIO(resp.content), **kwargs)
+
 POP_07_16_URL = 'https://raw.githubusercontent.com/weilu/mega-indicators/main/population/MOZ/moz_pop_2007-2016.csv'
-pop_07_16 = pd.read_csv(POP_07_16_URL, usecols=['region', 'Date', 'Value'])
+pop_07_16 = _fetch_csv(POP_07_16_URL, usecols=['region', 'Date', 'Value'])
 pop_07_16['data_source'] = 'https://mozambique.opendataforafrica.org/RDM2016'
 pop_07_16
 
 # COMMAND ----------
 
 POP_17_50_URL = 'https://raw.githubusercontent.com/weilu/mega-indicators/main/population/MOZ/moz_pop_2017-2050.csv'
-pop_17_50 = pd.read_csv(POP_17_50_URL, usecols=['província', 'Date', 'Value'])
+pop_17_50 = _fetch_csv(POP_17_50_URL, usecols=['província', 'Date', 'Value'])
 pop_17_50.rename(columns={'província': 'region'}, inplace=True)
 pop_17_50['data_source'] = 'https://mozambique.opendataforafrica.org/bumjrrg'
 pop_17_50

--- a/population/PRY/pry_subnational_population.py
+++ b/population/PRY/pry_subnational_population.py
@@ -7,10 +7,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
-# COMMAND ----------
-
 URL = 'https://www.ine.gov.py/microdatos/cuadro/b7dc2DEP01-Paraguay-Poblacion-total-por-anio-calendario-segun-sexo-y-departamento-2000-2025.csv'
 
 RAW_TABLE_NAME = 'pry_population_raw'

--- a/population/TUN/tun_subnational_population.py
+++ b/population/TUN/tun_subnational_population.py
@@ -3,8 +3,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
 # Shared download+parse across countries (wb_subnational_population_extract.py).
 ddf_pop = (
     spark.table(f'{INDICATOR_SCHEMA}.wb_subnational_population_silver')

--- a/population/ZAF/zaf_subnational_population.py
+++ b/population/ZAF/zaf_subnational_population.py
@@ -3,8 +3,6 @@
 
 # COMMAND ----------
 
-import pandas as pd
-
 # Shared download+parse across countries (wb_subnational_population_extract.py).
 ddf_pop = (
     spark.table(f'{INDICATOR_SCHEMA}.wb_subnational_population_silver')

--- a/population/subnational_population_official_dlt.py
+++ b/population/subnational_population_official_dlt.py
@@ -1,6 +1,5 @@
 # Databricks notebook source
 import dlt
-from pyspark.sql import functions as F
 
 # Adding a new country requires adding the country here
 country_codes = ['moz', 'pry', 'ken', 'pak', 'bfa', 'col', 'cod', 'tun', 'btn', 'chl', 'nga', 'bgd', 'alb', "zaf", 'chl', 'gha', 'lbr', 'tgo']

--- a/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
+++ b/poverty/subnational_poverty/subnational_poverty_index_extract_transform.py
@@ -20,7 +20,7 @@ import re
 # COMMAND ----------
 
 spid_resource_url = 'https://ddh-openapi.worldbank.org/resources/DR0092191'
-response = requests.get(spid_resource_url)
+response = requests.get(spid_resource_url, timeout=DEFAULT_TIMEOUT_SECONDS)
 response.raise_for_status()
 spid_url = response.json()['distribution']['url']
 # Prefer the mounted DDH volume; fall back to the URL (see ddh_bytes in utils).
@@ -32,7 +32,7 @@ df_SPID
 # COMMAND ----------
 
 gsap_resource_url = 'https://ddh-openapi.worldbank.org/resources/DR0052555'
-response = requests.get(gsap_resource_url)
+response = requests.get(gsap_resource_url, timeout=DEFAULT_TIMEOUT_SECONDS)
 response.raise_for_status()
 gsap_url = response.json()['distribution']['url']
 # expect the first sheet to be metadata, followed by the latest lineup data sheet

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,11 @@ import wbgapi as wb
 import pandas as pd
 from databricks.sdk.runtime import spark, dbutils
 
+DEFAULT_TIMEOUT_SECONDS = 60
+
+# wbgapi has no timeout by default, set it so a stalled connection doesn't hang forever
+wb.get_options = {'timeout': DEFAULT_TIMEOUT_SECONDS}
+
 def _wb_dataframe_with_retry(series, attempts=5, backoff=2.0):
     # World Bank's API intermittently 502s mid-pagination; retry the whole fetch.
     for i in range(attempts):
@@ -69,7 +74,7 @@ def uis_fetch(series_to_col_name, data_source, extra_col_names_from_country_tabl
         params.append(('start', start))
     if stop is not None:
         params.append(('stop', stop))
-    resp = requests.get(UIS_API_URL, params=params, timeout=60)
+    resp = requests.get(UIS_API_URL, params=params, timeout=DEFAULT_TIMEOUT_SECONDS)
     resp.raise_for_status()
     payload = resp.json()
     raw_df = pd.DataFrame.from_records(payload.get('records', []))
@@ -112,7 +117,7 @@ def ddh_bytes(url):
     if os.path.exists(vol):
         with open(vol, 'rb') as f:
             return f.read()
-    resp = requests.get(url)
+    resp = requests.get(url, timeout=DEFAULT_TIMEOUT_SECONDS)
     resp.raise_for_status()
     return resp.content
 
@@ -126,7 +131,7 @@ def fetch_raw(source_url, table_name, parse=pd.read_csv, **parse_kwargs):
 
     Delta's transaction log is the audit trail (DESCRIBE HISTORY / VERSION AS OF).
     """
-    resp = requests.get(source_url, timeout=60)
+    resp = requests.get(source_url, timeout=DEFAULT_TIMEOUT_SECONDS)
     resp.raise_for_status()
     df = parse(io.BytesIO(resp.content), **parse_kwargs)
     df['fetched_at'] = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary
- Add explicit timeouts (default 60s, `DEFAULT_TIMEOUT_SECONDS` in `utils.py`) to all bare `requests.get()` calls and to `wbgapi` globally (`wb.get_options`), so a stalled connection can't hang a task indefinitely — root cause of a ~39h hung prod cluster.
- Remove unused imports across 10 files flagged by pyflakes.

## Test plan
- [x] Deployed to staging, triggered `indicators_all`
- [ ] Confirm staging run completes successfully